### PR TITLE
Fix crash if a request times out

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,8 +161,7 @@ GL.prototype._getMap = function() {
                   req.url +
                   " complete in " +
                   duration +
-                  "ms.  Headers:" +
-                  JSON.stringify(res.headers || null)
+                  "ms."
               );
             } else {
               debug(

--- a/index.js
+++ b/index.js
@@ -156,13 +156,25 @@ GL.prototype._getMap = function() {
           function(err, res, body) {
             var duration = Date.now() - start;
             if (duration > 500) {
-              debug(
-                "Request for " +
-                  req.url +
-                  " complete in " +
-                  duration +
-                  "ms."
-              );
+              if(res === undefined) { // If request timed out response will be undefined
+                debug(
+                  "Request for " +
+                    req.url +
+                    " failed in " +
+                    duration +
+                    "ms."
+                );
+              } else {
+                // Headers are needed for debugging cases of slow responses from AWS s3
+                debug(
+                  "Request for " +
+                    req.url +
+                    " complete in " +
+                    duration +
+                    "ms.  Headers:" +
+                    JSON.stringify(res.headers || null)
+                );           
+              }
             } else {
               debug(
                 "Request for " + req.url + " complete in " + duration + "ms"


### PR DESCRIPTION
Fixes this error
```
 /opt/tessera/node_modules/tilelive-gl/index.js:165
                   JSON.stringify(res.headers || null)
                                      ^

 TypeError: Cannot read property 'headers' of undefined
     at Request._callback (/opt/tessera/node_modules/tilelive-gl/index.js:165:38)
     at self.callback (/opt/tessera/node_modules/tilelive-gl/node_modules/request/request.js:186:22)
     at emitOne (events.js:116:13)
     at Request.emit (events.js:211:7)
     at Request.onRequestError (/opt/tessera/node_modules/tilelive-gl/node_modules/request/request.js:878:8)
     at emitOne (events.js:116:13)
     at ClientRequest.emit (events.js:211:7)
     at Socket.socketErrorListener (_http_client.js:401:9)
     at emitOne (events.js:116:13)
     at Socket.emit (events.js:211:7)
```